### PR TITLE
Stub Starboard/Ozone layer

### DIFF
--- a/build/config/ozone_extra.gni
+++ b/build/config/ozone_extra.gni
@@ -5,13 +5,17 @@
 # This list contains the name of external platforms that are passed to the
 # --ozone-platform command line argument or used for the ozone_platform build
 # config. For example ozone_external_platforms = [ "foo1", "foo2", ... ]
-ozone_external_platforms = []
+ozone_external_platforms = [
+    "starboard"
+]
 
 # This list contains dependencies for external platforms. Typically, the Ozone
 # implementations are placed into ui/ozone/platform/ and so this will look
 # something like:
 # ozone_external_platform_deps = [ "platform/foo1", "platform/foo_2", ... ]
-ozone_external_platform_deps = []
+ozone_external_platform_deps = [
+    "platform/starboard"
+]
 
 # If a platform has unit tests, the corresponding source_set can be listed here
 # so that they get included into ozone_unittests.
@@ -25,7 +29,9 @@ ozone_external_platform_integration_test_deps = []
 # If a platform has test support files for ui, the corresponding source_set can
 # be listed here so that they get included into ui_test_support.
 # ozone_external_platform_ui_test_support_deps = [ "platform/foo1:ui_test_support", ... ]
-ozone_external_platform_ui_test_support_deps = []
+ozone_external_platform_ui_test_support_deps = [
+    "platform/starboard:ui_test_support"
+]
 
 # If a platform has a test support for interactive_ui_tests, the corresponding
 # source_set can be listed here so that they can included into

--- a/ui/ozone/platform/starboard/BUILD.gn
+++ b/ui/ozone/platform/starboard/BUILD.gn
@@ -1,0 +1,37 @@
+# Copyright 2016 The Chromium Authors
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import("//build/config/chromeos/ui_mode.gni")
+import("//gpu/vulkan/features.gni")
+import("//ui/base/ui_features.gni")
+
+visibility = [ "//ui/ozone/*" ]
+
+source_set("starboard") {
+  sources = [
+    "client_native_pixmap_factory_starboard.cc",
+    "client_native_pixmap_factory_starboard.h",
+    "ozone_platform_starboard.cc",
+    "ozone_platform_starboard.h",
+    "starboard_window.cc",
+    "starboard_window.h",
+  ]
+  defines = [
+    "OZONE_IMPLEMENTATION",
+  ]
+  deps = [
+    "//base"
+  ]
+}
+
+source_set("ui_test_support") {
+  testonly = true
+  sources = [
+    "starboard_ozone_ui_controls_test_helper.cc",
+    "starboard_ozone_ui_controls_test_helper.h",
+  ]
+  deps = [
+    "//base"
+  ]
+}

--- a/ui/ozone/platform/starboard/client_native_pixmap_factory_starboard.cc
+++ b/ui/ozone/platform/starboard/client_native_pixmap_factory_starboard.cc
@@ -1,0 +1,15 @@
+// Copyright 2024 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "ui/ozone/platform/starboard/client_native_pixmap_factory_starboard.h"
+
+#include "ui/gfx/client_native_pixmap_factory.h"
+
+namespace ui {
+
+gfx::ClientNativePixmapFactory* CreateClientNativePixmapFactoryStarboard() {
+    return nullptr;
+}
+
+}

--- a/ui/ozone/platform/starboard/client_native_pixmap_factory_starboard.h
+++ b/ui/ozone/platform/starboard/client_native_pixmap_factory_starboard.h
@@ -1,0 +1,19 @@
+// Copyright 2024 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef UI_OZONE_PLATFORM_STARBOARD_CLIENT_NATIVE_PIXMAP_FACTORY_STARBOARD_H_
+#define UI_OZONE_PLATFORM_STARBOARD_CLIENT_NATIVE_PIXMAP_FACTORY_STARBOARD_H_
+
+namespace gfx {
+class ClientNativePixmapFactory;
+}
+
+namespace ui {
+
+// Constructor hook for use in constructor_list.cc
+gfx::ClientNativePixmapFactory* CreateClientNativePixmapFactoryStarboard();
+
+}  // namespace ui
+
+#endif  // UI_OZONE_PLATFORM_STARBOARD_CLIENT_NATIVE_PIXMAP_FACTORY_STARBOARD_H_

--- a/ui/ozone/platform/starboard/ozone_platform_starboard.cc
+++ b/ui/ozone/platform/starboard/ozone_platform_starboard.cc
@@ -1,0 +1,13 @@
+// Copyright 2024 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "ui/ozone/platform/starboard/ozone_platform_starboard.h"
+
+namespace ui {
+
+OzonePlatform* CreateOzonePlatformStarboard() {
+    return nullptr;
+}
+
+}  // namespace ui

--- a/ui/ozone/platform/starboard/ozone_platform_starboard.h
+++ b/ui/ozone/platform/starboard/ozone_platform_starboard.h
@@ -1,0 +1,17 @@
+// Copyright 2024 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef UI_OZONE_PLATFORM_HEADLESS_OZONE_PLATFORM_STARBOARD_H_
+#define UI_OZONE_PLATFORM_HEADLESS_OZONE_PLATFORM_STARBOARD_H_
+
+namespace ui {
+
+class OzonePlatform;
+
+// Constructor hook for use in ozone_platform_list.cc
+OzonePlatform* CreateOzonePlatformStarboard();
+
+}  // namespace ui
+
+#endif  // UI_OZONE_PLATFORM_HEADLESS_OZONE_PLATFORM_STARBOARD_H_

--- a/ui/ozone/platform/starboard/starboard_ozone_ui_controls_test_helper.cc
+++ b/ui/ozone/platform/starboard/starboard_ozone_ui_controls_test_helper.cc
@@ -1,0 +1,13 @@
+// Copyright 2024 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "ui/ozone/platform/starboard/starboard_ozone_ui_controls_test_helper.h"
+
+namespace ui {
+
+OzoneUIControlsTestHelper* CreateOzoneUIControlsTestHelperStarboard() {
+  return nullptr;
+}
+
+}  // namespace ui

--- a/ui/ozone/platform/starboard/starboard_ozone_ui_controls_test_helper.h
+++ b/ui/ozone/platform/starboard/starboard_ozone_ui_controls_test_helper.h
@@ -1,0 +1,16 @@
+// Copyright 2024 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef UI_OZONE_PLATFORM_STARBOARD_STARBOARD_OZONE_UI_CONTROLS_TEST_HELPER_H_
+#define UI_OZONE_PLATFORM_STARBOARD_STARBOARD_OZONE_UI_CONTROLS_TEST_HELPER_H_
+
+#include "ui/ozone/public/ozone_ui_controls_test_helper.h"
+
+namespace ui {
+
+OzoneUIControlsTestHelper* CreateOzoneUIControlsTestHelperStarboard();
+
+}  // namespace ui
+
+#endif  // UI_OZONE_PLATFORM_STARBOARD_STARBOARD_OZONE_UI_CONTROLS_TEST_HELPER_H_

--- a/ui/ozone/platform/starboard/starboard_window.h
+++ b/ui/ozone/platform/starboard/starboard_window.h
@@ -1,0 +1,10 @@
+// Copyright 2014 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef UI_OZONE_PLATFORM_STARBOARD_STARBOARD_WINDOW_H_
+#define UI_OZONE_PLATFORM_STARBOARD_STARBOARD_WINDOW_H_
+
+#include <starboard/window.h>
+
+#endif // UI_OZONE_PLATFORM_STARBOARD_STARBOARD_WINDOW_H_


### PR DESCRIPTION
Scaffolds Starboard Ozone backend.

This is enough to make it compile and link, but of course it wont work. Several interfaces are also not scaffolded yet.



